### PR TITLE
ROCm(6.4.0): `roc-obj-ls` is deprecated and does not work in images

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,7 @@ jobs:
                   cache-from: type=registry,ref=${{ needs.set-vars.outputs.CI_IMAGE  }}
                   cache-to: type=inline
                   build-args: |
-                      BASE_IMAGE=rocm/dev-ubuntu-24.04:6.3.1
+                      BASE_IMAGE=rocm/dev-ubuntu-24.04:6.4
                   labels: "org.opencontainers.image.source=${{ github.repositoryUrl }}"
 
     tests-tools:

--- a/tests/tools/CMakeLists.txt
+++ b/tests/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_test(
     NAME tests_tools_parse_code_metadata
-    COMMAND python3 -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_parse_code_metadata.py -s
+    COMMAND python3 -m pytest ${CMAKE_CURRENT_SOURCE_DIR}/test_parse_code_metadata.py -s --log-cli-level=info
 )
 set_property(
     TEST tests_tools_parse_code_metadata


### PR DESCRIPTION
See also https://github.com/ROCm/ROCm/issues/4629.